### PR TITLE
Add GitHub Actions for multi-arch builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,86 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - main
+      - master
+      - release-*
+  pull_request:
+    branches:
+      - main
+      - master
+      - release-*
+  merge_group:
+    branches:
+      - main
+      - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  QEMU_VERSION: 7.0.0-7
+
+jobs:
+  build-multi-arch:
+    name: Build for ${{ matrix.arch }}
+    runs-on: ubuntu-latest
+    # Run steps on a matrix of 2 arch.
+    strategy:
+      fail-fast: false
+      matrix:
+        arch:
+          - amd64
+          - arm64
+    steps:
+      - uses: actions/checkout@v4.1.1
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build the builder image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile.builder
+          push: false
+          load: true
+          platforms: linux/${{ matrix.arch }}
+          tags: perf-map-agent-builder:latest
+
+      # - name: "Setup QEMU ${{ matrix.arch }}"
+      #   run: |
+      #     # Register QEMU
+      #     docker run --rm --privileged "docker.io/multiarch/qemu-user-static:${QEMU_VERSION}" --reset -p yes
+
+      - name: "Run Builder ${{ matrix.arch }}"
+        run: |
+          # Run platform specific based builder image. Run it as a daemon in the background.
+          # Sleep the container for 1 day so that it keeps running until
+          # other steps are completed and the steps below can use the same container.
+          docker run \
+            --name=builder \
+            --detach \
+            --platform 'linux/${{ matrix.arch }}' \
+            --volume /home/runner/work:/home/runner/work \
+            --workdir "${PWD}" \
+            docker.io/library/perf-map-agent-builder:latest \
+            bash -c 'uname -m && sleep 1d'
+
+      - name: "Build ${{ matrix.arch }}"
+        shell: docker exec builder bash -e {0}
+        run: |
+          cmake .
+          make
+
+      - name: Upload generated artifacts
+        uses: actions/upload-artifact@v3.1.3
+        with:
+          name: perf-map-agent-${{ matrix.arch }}
+          if-no-files-found: error
+          path: out/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8.6)
+cmake_minimum_required (VERSION 2.8.6...3.5)
 project (perf-map-agent)
 
 # uncomment to make a debug build (including source positions and symbols)
@@ -8,7 +8,12 @@ project (perf-map-agent)
 set(OUTDIR ${PROJECT_BINARY_DIR}/out)
 set(LIBRARY_OUTPUT_PATH ${OUTDIR})
 
-find_package(JNI)
+# If the Java environment is properly NOT set, use the following:
+set(JAVA_INCLUDE_PATH "$ENV{JAVA_HOME}/include")
+set(JAVA_INCLUDE_PATH2 "$ENV{JAVA_HOME}/include/linux")
+set(JAVA_AWT_INCLUDE_PATH "$ENV{JAVA_HOME}/include")
+
+find_package(JNI REQUIRED)
 if (JNI_FOUND)
     message (STATUS "JNI_INCLUDE_DIRS=${JNI_INCLUDE_DIRS}")
     message (STATUS "JNI_LIBRARIES=${JNI_LIBRARIES}")

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,0 +1,7 @@
+FROM openjdk:22-slim-bookworm
+
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    cmake \
+    git \
+    && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>

```shell
❯ file ~/Downloads/perf-map-agent-amd64/libperfmap.so
/Users/kakkoyun/Downloads/perf-map-agent-amd64/libperfmap.so: ELF 64-bit LSB shared object, x86-64, version 1 (SYSV), dynamically linked, BuildID[sha1]=807f3589c3495f67416a677b60884ca5d46ef4d2, not stripped

# 

❯ file ~/Downloads/perf-map-agent-arm64/libperfmap.so
/Users/kakkoyun/Downloads/perf-map-agent-arm64/libperfmap.so: ELF 64-bit LSB shared object, ARM aarch64, version 1 (SYSV), dynamically linked, BuildID[sha1]=3a4cc460d8e3a0c633fa7bd8698ff75024324162, not stripped
```
